### PR TITLE
ENH: Fixing border rounding and simplify UI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 html_theme = "sphinx_book_theme"
+# html_theme = "sphinx_rtd_theme"
+# html_theme = "furo"
 
 html_theme_options = {
     "repository_url": "https://github.com/executablebooks/sphinx-examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ sphinx = [
     "sphinx-book-theme",
     "sphinx-copybutton",
     "myst-parser",
+    # Extra theme dependencies to test
+    "sphinx-rtd-theme",
+    "furo",
 ]
 
 [tool.flit.module]

--- a/src/sphinx_examples/__init__.py
+++ b/src/sphinx_examples/__init__.py
@@ -36,8 +36,9 @@ TEMPLATE_SOURCE = """
 :::::::::::::::::::::::{{grid-item-card}}
 :columns: 12
 :shadow: none
+:class-item: sd-example-item
 :class-header: bg-light py-1 fs-1
-:class-card: sd-example-source
+:class-card: sd-example-source{extra_classes}
 
 Source
 ^^^
@@ -54,8 +55,9 @@ TEMPLATE_RESULT = """
 :::::::::::::::::::::::{{grid-item-card}}
 :columns: 12
 :shadow: none
+:class-item: sd-example-item
 :class-header: bg-light py-1
-:class-card: sd-example-result
+:class-card: sd-example-result{extra_classes}
 
 
 Result
@@ -139,8 +141,10 @@ class ExampleDirective(SphinxDirective):
             if "reverse" in self.options:
                 content_templates = content_templates[::-1]
 
-            for template in content_templates:
-                grid_items.append(template.format(content=content_text))
+            extra_classes = [" sd-flat-bottom", " sd-flat-top"]
+            for (template, classes) in zip(content_templates, extra_classes):
+                template = template.format(content=content_text, extra_classes=classes)
+                grid_items.append(template)
 
             # Use Sphinx Design to parse content
             grid_text = TEMPLATE_GRID.format(content="\n".join(grid_items))

--- a/src/sphinx_examples/__init__.py
+++ b/src/sphinx_examples/__init__.py
@@ -37,11 +37,8 @@ TEMPLATE_SOURCE = """
 :columns: 12
 :shadow: none
 :class-item: sd-example-item
-:class-header: bg-light py-1 fs-1
-:class-card: sd-example-source{extra_classes}
-
-Source
-^^^
+:class-card: sd-example-source {extra_classes}
+:class-body: sd-p-0
 
 ``````````````````````````````markdown
 {content}
@@ -56,12 +53,7 @@ TEMPLATE_RESULT = """
 :columns: 12
 :shadow: none
 :class-item: sd-example-item
-:class-header: bg-light py-1
-:class-card: sd-example-result{extra_classes}
-
-
-Result
-^^^
+:class-card: sd-example-result {extra_classes}
 
 {content}
 
@@ -141,7 +133,7 @@ class ExampleDirective(SphinxDirective):
             if "reverse" in self.options:
                 content_templates = content_templates[::-1]
 
-            extra_classes = [" sd-flat-bottom", " sd-flat-top"]
+            extra_classes = ["sd-flat-bottom", "sd-flat-top"]
             for (template, classes) in zip(content_templates, extra_classes):
                 template = template.format(content=content_text, extra_classes=classes)
                 grid_items.append(template)

--- a/src/sphinx_examples/_static/styles/sphinx-examples.css
+++ b/src/sphinx_examples/_static/styles/sphinx-examples.css
@@ -1,17 +1,22 @@
 /**
  * Example directive styling
  */
-.sd-example .sd-card-header {
-    font-size: .8em;
-}
 
 .sd-example-title p {
-    margin: 0;
-    font-size:.9em;
+    margin: 0 0 .2em 0;
+    font-size: .9em;
+    font-style: italic;
 }
 
 .sd-example-source div[class*="highlight-"], .sd-example-source div.highlight {
     margin: 0;
+}
+
+.sd-example-source pre {
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1.5rem 1rem;
 }
 
 /* Cards should be flush w/ one another at their intersection */

--- a/src/sphinx_examples/_static/styles/sphinx-examples.css
+++ b/src/sphinx_examples/_static/styles/sphinx-examples.css
@@ -1,32 +1,33 @@
 /**
  * Example directive styling
  */
-
 .sd-example-title p {
     margin: 0 0 .2em 0;
     font-size: .9em;
     font-style: italic;
 }
 
-.sd-example-source div[class*="highlight-"], .sd-example-source div.highlight {
+.sd-example-source div[class*="highlight-"],
+.sd-example-source div.highlight,
+.sd-example-source pre {
     margin: 0;
+    border: none;
+    box-shadow: none;
+    border-radius: .25rem; /* Same as .sd-card */
 }
 
 .sd-example-source pre {
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
     padding: 1.5rem 1rem;
 }
 
 /* Cards should be flush w/ one another at their intersection */
-.sd-card.sd-flat-bottom {
+.sd-example .sd-card.sd-flat-bottom {
     border-bottom-right-radius: 0em;
     border-bottom-left-radius: 0em;
     border-bottom: 0;
 }
 
-.sd-card.sd-flat-top {
+.sd-example .sd-card.sd-flat-top {
     border-top-right-radius: 0em;
     border-top-left-radius: 0em;
 }

--- a/src/sphinx_examples/_static/styles/sphinx-examples.css
+++ b/src/sphinx_examples/_static/styles/sphinx-examples.css
@@ -13,3 +13,15 @@
 .sd-example-source div[class*="highlight-"], .sd-example-source div.highlight {
     margin: 0;
 }
+
+/* Cards should be flush w/ one another at their intersection */
+.sd-card.sd-flat-bottom {
+    border-bottom-right-radius: 0em;
+    border-bottom-left-radius: 0em;
+    border-bottom: 0;
+}
+
+.sd-card.sd-flat-top {
+    border-top-right-radius: 0em;
+    border-top-left-radius: 0em;
+}


### PR DESCRIPTION
Makes the borders flush with each other between cards.

Also removes the "header" in each card, and updates the `source` style so that it is obvious what is source and what is result. This simplifies the UI a bit.