### PR TITLE
Using grid instead of card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,23 @@ A small sphinx extension to add "example snippets" that allow you to show off so
 
 For example:
 
-```{example} Showing off a note directive
+````{example} Showing off a card and note directive
 
+```{card}
+:class-header: bg-light
+A note!
+^^^
 :::{note}
 Here's a sample note!
 :::
 ```
 
+````
+
 :::{warning}
 This currently only works with MyST Markdown content, it will not work if you've written your documentation in reStructuredText.
 :::
+
 
 ## Install
 

--- a/src/sphinx_examples/__init__.py
+++ b/src/sphinx_examples/__init__.py
@@ -10,7 +10,7 @@ __version__ = "0.0.3"
 
 
 TEMPLATE_GRID = """
-::::::::::::::::::::::::{{grid}}
+`````````````````````````````````````{{grid}}
 :gutter: 0
 :margin: 0 2 0 0
 :padding: 0
@@ -18,47 +18,45 @@ TEMPLATE_GRID = """
 
 {content}
 
-::::::::::::::::::::::::
+`````````````````````````````````````
 """
 
 TEMPLATE_TITLE = """
-:::::::::::::::::::::::{{grid-item}}
+````````````````````````````````````{{grid-item}}
 :columns: 12
 :class: sd-example-title
 
 {content}
 
-:::::::::::::::::::::::
+````````````````````````````````````
 """
 
 TEMPLATE_SOURCE = """
 
-:::::::::::::::::::::::{{grid-item-card}}
+````````````````````````````````````{{grid-item}}
 :columns: 12
-:shadow: none
-:class-item: sd-example-item
-:class-card: sd-example-source {extra_classes}
-:class-body: sd-p-0
+:class: sd-example-item sd-example-source {extra_classes}
 
 ``````````````````````````````markdown
+
 {content}
+
 ``````````````````````````````
 
-:::::::::::::::::::::::
+````````````````````````````````````
 """
 
 TEMPLATE_RESULT = """
 
-:::::::::::::::::::::::{{grid-item-card}}
+````````````````````````````````````{{grid-item}}
 :columns: 12
-:shadow: none
-:class-item: sd-example-item
-:class-card: sd-example-result {extra_classes}
+:class: sd-example-item p-3 sd-example-result {extra_classes}
 
+```````````````````````````````````{{div}} result-content
 {content}
+```````````````````````````````````
 
-
-:::::::::::::::::::::::
+````````````````````````````````````
 """
 
 
@@ -133,7 +131,7 @@ class ExampleDirective(SphinxDirective):
             if "reverse" in self.options:
                 content_templates = content_templates[::-1]
 
-            extra_classes = ["sd-flat-bottom", "sd-flat-top"]
+            extra_classes = ["sd-rounded-top", "sd-rounded-bottom"]
             for (template, classes) in zip(content_templates, extra_classes):
                 template = template.format(content=content_text, extra_classes=classes)
                 grid_items.append(template)

--- a/src/sphinx_examples/_static/styles/sphinx-examples.css
+++ b/src/sphinx_examples/_static/styles/sphinx-examples.css
@@ -7,6 +7,10 @@
     font-style: italic;
 }
 
+.sd-example-item {
+    border: 1px solid var(--sd-color-card-border);
+}
+
 .sd-example-source div[class*="highlight-"],
 .sd-example-source div.highlight,
 .sd-example-source pre {
@@ -21,13 +25,13 @@
 }
 
 /* Cards should be flush w/ one another at their intersection */
-.sd-example .sd-card.sd-flat-bottom {
-    border-bottom-right-radius: 0em;
-    border-bottom-left-radius: 0em;
-    border-bottom: 0;
+.sd-example .sd-rounded-bottom {
+    border-bottom-right-radius: .25rem;
+    border-bottom-left-radius: .25rem;
 }
 
-.sd-example .sd-card.sd-flat-top {
-    border-top-right-radius: 0em;
-    border-top-left-radius: 0em;
+.sd-example .sd-rounded-top {
+    border-top-right-radius: .25rem;
+    border-top-left-radius: .25rem;
+    border-bottom: 0;
 }


### PR DESCRIPTION
This uses the `{grid}` directive instead of the `{card}` directive, which makes it possible to use `{example}` to demonstrate sphinx-design card syntax. Otherwise, it picks up the `^^^` and messes up the parsing