### PR TITLE
Fixing kwarg error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,10 @@ For example:
 
 ````{example} Showing off a card and note directive
 
-```{card}
-:class-header: bg-light
-A note!
-^^^
 :::{note}
 Here's a sample note!
 :::
-```
+
 
 ````
 
@@ -93,5 +89,6 @@ A full-width note!
 ````
 
 ```{toctree}
+reference
 changelog
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,31 @@
+# Reference examples
+
+The following examples show off the look and feel of this extension.
+They also serve as an informal test-suite - none of them should result in problematic output or warnings.
+
+As we discover edge-cases and bugs, add new examples below to confirm they work once fixed.
+
+## `{card}` directive
+
+````{example} Card directive with a header should be properly parsed.
+
+```{card}
+:class-header: bg-light
+A note!
+^^^
+:::{note}
+Here's a sample note!
+:::
+```
+
+````
+
+## Colon fence
+
+````{example} Example with colon fence should not result in kwarg error
+
+:::{note}
+A note!
+:::
+
+````

--- a/src/sphinx_examples/__init__.py
+++ b/src/sphinx_examples/__init__.py
@@ -53,7 +53,9 @@ TEMPLATE_RESULT = """
 :class: sd-example-item p-3 sd-example-result {extra_classes}
 
 ```````````````````````````````````{{div}} result-content
+
 {content}
+
 ```````````````````````````````````
 
 ````````````````````````````````````


### PR DESCRIPTION
Fixes a bug where adding a colon-fence directive inside of the example would create a kwarg error.